### PR TITLE
Added mass register funcs and example used as test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ a Ponzu addon to create a web frontend for your CMS.
 
 ### To install:
 
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/bosssauce/frontend)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bosssauce/frontend)](https://goreportcard.com/report/github.com/bosssauce/frontend)
+
 from within your Ponzu project, run:
 ```bash
 $ ponzu add github.com/bosssauce/frontend

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,50 @@
+package frontend_test
+
+import (
+	"fmt"
+	"github.com/bosssauce/frontend"
+	"net/http"
+)
+
+func viewHomePage(res http.ResponseWriter, req *http.Request) {
+	res.Write([]byte("HomePage"))
+}
+
+func viewOther(res http.ResponseWriter, req *http.Request) {
+	vars := frontend.Vars(req)
+	res.Write([]byte("this is page " + vars["keyName"]))
+}
+
+func postOther(res http.ResponseWriter, req *http.Request) {
+	res.Write([]byte("PostOther"))
+}
+
+func Example_register() { // Use in init()
+
+	frontend.RegisterGet(frontend.ListHandle{{
+		URL:     "/",
+		Handler: viewHomePage,
+	}, {
+		URL:     "/other/{keyName}",
+		Handler: viewOther,
+	}}.ToHandlers()...)
+
+	frontend.RegisterPost(frontend.ListHandle{{
+		URL:     "/other",
+		Handler: postOther,
+	}}.ToHandlers()...)
+
+	runTest() // Simple tests.
+	// Output:
+	// HomePage
+	// this is page test
+	// this is page another
+}
+
+func runTest() {
+	url := "localhost:7357"
+	testServer(url)
+	fmt.Println(testGet(url, "/"))
+	fmt.Println(testGet(url, "/other/test"))
+	fmt.Println(testGet(url, "/other/another"))
+}

--- a/hidden_test.go
+++ b/hidden_test.go
@@ -1,0 +1,25 @@
+package frontend_test
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+// this is only needed for the go test.
+func testServer(url string) {
+	go http.ListenAndServe(url, nil)
+}
+
+func testGet(url, page string) string {
+	resp, err := http.Get("http://" + url + page)
+	if err != nil {
+		return err.Error()
+	}
+	defer resp.Body.Close()
+
+	text, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err.Error()
+	}
+	return string(text)
+}

--- a/router.go
+++ b/router.go
@@ -1,3 +1,10 @@
+/*
+Package frontend is a ponzu addon to handle page routing for your ponzu site.
+
+Usage
+
+See example.
+*/
 package frontend
 
 import (
@@ -7,27 +14,63 @@ import (
 )
 
 type router struct {
-	mux *mux.Router
+	*mux.Router
 }
 
 var (
 	// Router is exported so any content type file can just call frontend.Router.HandleFunc(....
 	// otherwise, a New() func might be needed, but it is not clear where it should be called from
-	Router *router
+	Router = &router{
+		Router: mux.NewRouter(),
+	}
 )
 
-func (r *router) HandleFunc(path string, fn func(http.ResponseWriter, *http.Request)) {
-	r.mux.HandleFunc(path, fn)
-}
-
-func (r *router) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	r.mux.ServeHTTP(res, req)
-}
-
 func init() {
-	Router = &router{
-		mux: mux.NewRouter(),
-	}
-
 	http.Handle("/", Router)
+}
+
+// Vars returns the route variables for the current request, if any.
+func Vars(req *http.Request) map[string]string {
+	return mux.Vars(req)
+}
+
+// RegisterGet registers GET handlers.
+func RegisterGet(toHandle ...ToHandler) {
+	for _, hand := range toHandle {
+		Router.HandleFunc(hand.ToHandler()).Methods("GET")
+	}
+}
+
+// RegisterPost registers POST handlers.
+func RegisterPost(toHandle ...ToHandler) {
+	for _, hand := range toHandle {
+		Router.HandleFunc(hand.ToHandler()).Methods("POST")
+	}
+}
+
+// ToHandler defines a registrable handler with routing path.
+type ToHandler interface {
+	ToHandler() (url string, handler http.HandlerFunc)
+}
+
+// ToHandle defines a route to register with an URL and Handler func.
+type ToHandle struct {
+	URL     string
+	Handler http.HandlerFunc
+}
+
+// ToHandler implements ToHandler.
+func (th ToHandle) ToHandler() (string, http.HandlerFunc) {
+	return th.URL, th.Handler
+}
+
+// ListHandle defines a list of ToHandle.
+type ListHandle []ToHandle
+
+// ToHandlers converts the list to a list of interface ToHandler.
+func (l ListHandle) ToHandlers() (handlers []ToHandler) {
+	for _, handle := range l {
+		handlers = append(handlers, handle)
+	}
+	return
 }


### PR DESCRIPTION
- The router type now just extends the mux.Router so we can use it directly (and get the returned object from HandleFunc to add more options).
- RegisterGet and RegisterPost are used to add lists of routes (see example).
- The example shows how to register handlers and 2 of its 3 paths are used in the test (need POST).